### PR TITLE
Ensure support for Python 3.8, 3.9, 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyflowlauncher==0.6.1.dev0
 pygithub==1.54
+typing-extensions==4.9.0


### PR DESCRIPTION
Ensure `typing-extension` dependency backport to support `NotRequired` for older Python versions.